### PR TITLE
Add maven plugin to build and run it from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ Features
  - redirect native output streams (on Linux)
 
 ...and a whole bunch of other nifty stuff.
- 
+
+Usage
+-----
+
+```shell
+## Compile and run it locally
+mvn clean compile exec:java
+```
 
 Status
 ------

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <mainClass>uk.co.caprica.vlcjplayer.VlcjPlayer</mainClass>
+                    <arguments>
+                        <argument>https://youtu.be/XHprwDJ0-fU</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
Hi @caprica,

This PR make it easier to run the project from the command line using Maven.

e.g.

```shell
mvn clean compile exec:java
```

It works perfectly for me on my Linux machine.

Best,
Burin